### PR TITLE
Define Lua vars as `local` to avoid bugs from global scope

### DIFF
--- a/orderedwrandom.lua
+++ b/orderedwrandom.lua
@@ -35,17 +35,17 @@ function orderedwrandom(servers, dq)
 	end
 
 	-- Create server list table
-	serverlist = {}
+	local serverlist = {}
 
 	-- Loop over each server for the pool
-	i = 1
+	local i = 1
 	while servers[i] do
 
 		-- We only care if the server is currently up
 		if (servers[i].upStatus == true) then
 
 			-- Retrieve the order for the server
-			order = servers[i].order
+			local order = servers[i].order
 
 			-- Create table for this order if not existing
 			if type(serverlist[order]) ~= "table" then
@@ -63,6 +63,7 @@ function orderedwrandom(servers, dq)
 	end
 
 	-- Get the lowest key in the table so that we use the lowest ordered server(s)
+  local lowest = nil
 	for k,v in pairs (serverlist) do
 		if lowest == nil then
 			lowest = k


### PR DESCRIPTION
When using 3 sets of "orders", this code wasn't behaving as expected (if all in 1 are down, use servers order==2, etc.) ... instead the behavior was that if the lowest order servers were unavailable, all remaining servers were used. This is because `lowest` always kept the value of 1 if it was ever 1, which means the fail-safe code block `if serverlist[lowest] == nil` was executed.

adding the `local` qualifier for `lowest` fixes this, I added `local` for the other vars, too, just because that seems like how they're intended (others are initialized within the function, so they're likely safe, `lowest` was never initialized)